### PR TITLE
feature/add-search-functionality-to-filter-table-results

### DIFF
--- a/src/lib/table.svelte
+++ b/src/lib/table.svelte
@@ -89,7 +89,7 @@
         })
     );
 
-    let sortedCourses = $derived(filteredCourses.sort((A, B) => {
+    let sortedCourses = $derived([...filteredCourses].sort((A, B) => {
         const a = A[sortColumn];
         const b = B[sortColumn];
 

--- a/src/lib/table.svelte
+++ b/src/lib/table.svelte
@@ -73,7 +73,23 @@
         });
     }
 
-    let sortedCourses = $derived(Object.values(courses).sort((A, B) => {
+    // SEARCH
+
+    let searchQuery = $state("");
+
+    let filteredCourses = $derived(
+        Object.values(courses).filter((course) => {
+            if (!searchQuery.trim()) return true;
+
+            const query = searchQuery.toLowerCase();
+            return (
+                course.name.toLowerCase().includes(query) ||
+                course.id.toLowerCase().includes(query)
+            );
+        })
+    );
+
+    let sortedCourses = $derived(filteredCourses.sort((A, B) => {
         const a = A[sortColumn];
         const b = B[sortColumn];
 
@@ -325,6 +341,40 @@
         {/if}
     </div>
 
+    <!-- Desktop: Search bar -->
+    <div class="mb-3 px-4 flex-shrink-0 hidden lg:block">
+        <div class="relative">
+            <input
+                type="text"
+                bind:value={searchQuery}
+                placeholder="Search courses by name or code"
+                class="w-full px-4 py-2 pl-10 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+            />
+            <svg
+                class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+            >
+                <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                />
+            </svg>
+            {#if searchQuery}
+                <button
+                    class="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
+                    onclick={() => (searchQuery = "")}
+                    title="Clear search"
+                >
+                    ✕
+                </button>
+            {/if}
+        </div>
+    </div>
+
     <!-- Mobile: Column selector and action buttons -->
     <div class="lg:hidden px-4 mb-2 flex justify-between items-center gap-2">
         <div class="flex items-center gap-2">
@@ -399,6 +449,40 @@
                 </button>
             </div>
         {/if}
+    </div>
+
+    <!-- Mobile: Search bar -->
+    <div class="lg:hidden px-4 mb-2 flex-shrink-0">
+        <div class="relative">
+            <input
+                type="text"
+                bind:value={searchQuery}
+                placeholder="Search courses by name or code"
+                class="w-full px-3 py-2 pl-9 text-sm rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+            />
+            <svg
+                class="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+            >
+                <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                />
+            </svg>
+            {#if searchQuery}
+                <button
+                    class="absolute right-2.5 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors text-sm"
+                    onclick={() => (searchQuery = "")}
+                    title="Clear search"
+                >
+                    ✕
+                </button>
+            {/if}
+        </div>
     </div>
 
     <div class="block px-4 flex-1 min-h-0 overflow-y-auto">

--- a/src/lib/table.svelte
+++ b/src/lib/table.svelte
@@ -98,6 +98,11 @@
         return sortDirection === "asc" ? comparison : -comparison;
     }));
 
+    // Check if there are any visible courses after filtering
+    let hasVisibleCourses = $derived(
+        sortedCourses.some((course) => $activeRows.has(course.id))
+    );
+
     // CSS
 
     let activeColor = $derived(`bg-${trackTailwindColors[$activeReq.track] || "gray"}-100`);
@@ -523,38 +528,46 @@
                 </tr>
             </thead>
             <tbody class="table-body">
-                {#each sortedCourses as course}
-                    {#if $activeRows.has(course.id)}
-                        <tr
-                            class="data-[active=true]:font-semibold > first:td"
-                            data-active={$activeCourses.has(course.id)}
-                        >
-                            {#each columns.slice(0, -1) as column, i}
-                                <td
-                                    class="table-cell"
-                                    class:text-right={rightAlignedColumns.has(
-                                        column,
-                                    )}
-                                    onclick={() => toggleCourse(course.id)}
-                                    title={typeof course[column] === "number"
-                                        ? course[column].toFixed(1)
-                                        : course[column]}
-                                >
-                                    {typeof course[column] === "number"
-                                        ? course[column].toFixed(1)
-                                        : course[column] ?? "-"}
+                {#if !hasVisibleCourses}
+                    <tr>
+                        <td colspan={columns.length} class="text-center py-8 text-gray-500 border-b border-gray-200">
+                            No results found
+                        </td>
+                    </tr>
+                {:else}
+                    {#each sortedCourses as course}
+                        {#if $activeRows.has(course.id)}
+                            <tr
+                                class="data-[active=true]:font-semibold > first:td"
+                                data-active={$activeCourses.has(course.id)}
+                            >
+                                {#each columns.slice(0, -1) as column, i}
+                                    <td
+                                        class="table-cell"
+                                        class:text-right={rightAlignedColumns.has(
+                                            column,
+                                        )}
+                                        onclick={() => toggleCourse(course.id)}
+                                        title={typeof course[column] === "number"
+                                            ? course[column].toFixed(1)
+                                            : course[column]}
+                                    >
+                                        {typeof course[column] === "number"
+                                            ? course[column].toFixed(1)
+                                            : course[column] ?? "-"}
+                                    </td>
+                                {/each}
+                                <td class="table-cell text-right" title={course.numReviews}>
+                                    <a
+                                        class="review-link"
+                                        href={reviewURL(course.name)}
+                                        target="_blank">{course.numReviews}</a
+                                    >
                                 </td>
-                            {/each}
-                            <td class="table-cell text-right" title={course.numReviews}>
-                                <a
-                                    class="review-link"
-                                    href={reviewURL(course.name)}
-                                    target="_blank">{course.numReviews}</a
-                                >
-                            </td>
-                        </tr>
-                    {/if}
-                {/each}
+                            </tr>
+                        {/if}
+                    {/each}
+                {/if}
             </tbody>
         </table>
     </div>


### PR DESCRIPTION
## Summary
Adds real-time search functionality to filter courses by name or code, with responsive desktop and mobile interfaces.

## Changes
- **Search logic**: Added `searchQuery` state and `filteredCourses` derived state
- **Desktop UI**: Full-width search bar with search icon and clear button
- **Mobile UI**: Compact search bar optimized for smaller screens
- **Integration**: Works with existing sorting and filtering features

## Key Features
- Real-time filtering as user types
- Case-insensitive search across course names and codes
- Clear button (✕) appears when text is present
- "No results found" message when search returns empty
- Responsive design for all screen sizes
- Maintains existing sort/filter functionality

## Testing
- Search by course name/code (partial matches)
- Case-insensitive search
- Clear button functionality
- "No results found" message displays when no matches are found
- Integration with sorting/filtering
- Responsive design
- Empty search shows all courses

## Screenshots

## Desktop

### Default
<img width="1512" height="982" alt="desktop-default" src="https://github.com/user-attachments/assets/22724592-1e21-44fa-aad5-5cb9ea6d2639" />

### No results
<img width="1512" height="982" alt="desktop-no-results" src="https://github.com/user-attachments/assets/352243e7-41f3-4ca4-8d7b-b9a959a8cb34" />

### Text search
<img width="1512" height="982" alt="desktop-text-search" src="https://github.com/user-attachments/assets/2028bffa-9121-4932-9b68-e2b9e766db1e" />

### Course number
<img width="1512" height="982" alt="desktop-course-number-search" src="https://github.com/user-attachments/assets/372e7ba0-14fb-479f-81c5-a8fb7d19528b" />

### Search + column sort
<img width="688" height="338" alt="desktop-search-and-column-sort" src="https://github.com/user-attachments/assets/0b63d66a-68ae-4445-b47b-5e7e0a25909c" />

## Mobile

### Default
<img width="416" height="716" alt="mobile-default" src="https://github.com/user-attachments/assets/629ed182-77a5-4bb8-8bf9-19af797a76ea" />

### No results
<img width="363" height="685" alt="mobile-no-results" src="https://github.com/user-attachments/assets/a2fd2582-20ff-45ea-a4e3-19b8e5217d8f" />

### Text search
<img width="357" height="697" alt="mobile-text-search" src="https://github.com/user-attachments/assets/3f6b20d5-30ac-4bc7-889c-195608e5320a" />

### Course number
<img width="356" height="694" alt="mobile-course-number-search" src="https://github.com/user-attachments/assets/7e4e1a90-ed0a-455d-97dc-530d9cdf96af" />

### Search + column sort
<img width="376" height="695" alt="mobile-search-and-column-sort" src="https://github.com/user-attachments/assets/666c6b99-d470-4e2e-b220-5a46f8376824" />

