### PR TITLE
Fix Formatting for OMSCentral Review URLs

### DIFF
--- a/src/lib/table.svelte
+++ b/src/lib/table.svelte
@@ -145,7 +145,7 @@
     function kebabCase(str) {
         return str
             .toLowerCase()
-            .replace(/[^a-z0-9\s]/g, "")
+            .replace(/[^a-z0-9\s-]/g, "")
             .trim()
             .replace(/\s+/g, "-");
     }

--- a/src/lib/table.svelte
+++ b/src/lib/table.svelte
@@ -147,7 +147,8 @@
             .toLowerCase()
             .replace(/[^a-z0-9\s-]/g, "")
             .trim()
-            .replace(/\s+/g, "-");
+            .replace(/\s+/g, "-")
+            .replace(/-+/g, "-");
     }
 
     function exportData() {


### PR DESCRIPTION
Updates regex used in `kebabCase` to better match the links to the OMSCentral review pages. 

**Before**: "Knowledge-Based AI" -> `knowledgebased-ai` (https://www.omscentral.com/courses/knowledgebased-ai/reviews)
**After**: "Knowledge-Based AI" -> `knowledge-based-ai` (https://www.omscentral.com/courses/knowledge-based-ai/reviews)